### PR TITLE
provide description_short for all

### DIFF
--- a/processed/codebook.csv
+++ b/processed/codebook.csv
@@ -3,22 +3,22 @@ other,unit,Unit,Unit
 other,name,Name,Name
 other,group,Group,Group
 other,pop_100k,Population in 100'000,Population
-other,new_cases_orig,Daily number of cases reported,
-other,new_deaths_orig,Daily number of deaths reported,
-other,new_tests_orig,Daily number of tests reported,
-other,cum_tests_orig,Cumulative number of tests reported,
-other,cap_cum_cases,Cumulative number of cases per capita,
+other,new_cases_orig,Daily number of cases reported,Daily Cases
+other,new_deaths_orig,Daily number of deaths reported,Daily Deaths
+other,new_tests_orig,Daily number of tests reported,Daily Tests
+other,cum_tests_orig,Cumulative number of tests reported,Cumulative Tests
+other,cap_cum_cases,Cumulative number of cases per capita,Cumulative Cases/100k
 default,cap_new_cases,Daily number of cases per capita (7 day rolling average),Cases/100k
-other,cap_cum_deaths,Cumulative number of deaths per capita,
+other,cap_cum_deaths,Cumulative number of deaths per capita,Cumulative Deaths/100k
 default,cap_new_deaths,Daily number of cases per capita (7 day rolling average),Deaths/100k
-other,cap_cum_tests,Cumulative number of tests per capita (smoothed),
+other,cap_cum_tests,Cumulative number of tests per capita (smoothed),Cumulative Tests/100k
 default,cap_new_tests,Daily number of tests per capita (7 day rolling average smoothed),Tests/100k
-other,all_cum_cases,Cumulative number of cases,
-other,all_new_cases,Daily number of cases (7 day rolling average),
-other,all_cum_deaths,Cumulative number of deaths,
-other,all_new_deaths,Daily number of cases (7 day rolling average),
-other,all_cum_tests,Cumulative number of tests (smoothed),
-other,all_new_tests,Daily number of tests (7 day rolling average smoothed),
+other,all_cum_cases,Cumulative number of cases,Cumulative Cases
+other,all_new_cases,Daily number of cases (7 day rolling average),Daily Cases
+other,all_cum_deaths,Cumulative number of deaths,Cumulative Deaths
+other,all_new_deaths,Daily number of cases (7 day rolling average),Daily Deaths
+other,all_cum_tests,Cumulative number of tests (smoothed),Cumulative Tests
+other,all_new_tests,Daily number of tests (7 day rolling average smoothed),Daily Tests
 default,pos,Positivity rate (7 day rolling average),Positivity rate (%)
 other,continent,Continent,Continent
 other,who_region,WHO Region,WHO Region


### PR DESCRIPTION
Add a short description for all the variables that do not yet have.

Required to resolve: https://github.com/dsbbfinddx/shinyfindapps/issues/45